### PR TITLE
Using RPDB_PORT env variable instead of binding rpdb port as default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,11 @@ pull_image:
 	docker pull $(DOCKER_IMAGE)
 
 docker_shell :: pull_image
-	docker run -p 4444:4444 -it $(EXPORTS) --rm $(DOCKER_VOLUMES) $(DOCKER_IMAGE)
+ifndef RPDB_PORT
+	docker run -it $(EXPORTS) --rm $(DOCKER_VOLUMES) $(DOCKER_IMAGE)
+else
+	docker run -p $(RPDB_PORT):4444 -it $(EXPORTS) --rm $(DOCKER_VOLUMES) $(DOCKER_IMAGE)
+endif
 
 docker_run_salt_unit_tests :: pull_image
 	docker run $(EXPORTS) --rm $(DOCKER_VOLUMES) $(DOCKER_IMAGE) run_salt_unit_tests

--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ make docker_shell DOCKER_IMAGE=registry.mgr.suse.de/toaster-sles12sp1
 make docker_shell VERSION=sles12sp1
 ```
 
+#### Run docker shell in repository image based on version and flavor
+```bash
+make docker_shell VERSION=sles12sp1 FLAVOR="testing"
+```
+
+#### Run docker shell in repository image based on version and bind rpdb port
+```bash
+make docker_shell VERSION=sles12sp1 RPDB_PORT="4444"
+```
+
 
 ## For development
 


### PR DESCRIPTION
The `docker_shell ` command of `salt-toaster` binds port `4444` by default for rpdb debugging. This causes that several `docker_shell` cannot run at the same time.

This PR introduces the use of `RPDB_PORT` env variable in order to bind the rpdb to certain port only when this env variable is used.