### PR TITLE
Salt SSH port forwarding

### DIFF
--- a/tests/scripts/netsend.sh
+++ b/tests/scripts/netsend.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo $1 | /usr/bin/nc localhost $2

--- a/tests/scripts/socket_server.py
+++ b/tests/scripts/socket_server.py
@@ -1,0 +1,72 @@
+#!/usr/bin/python
+import os
+import sys 
+import socket
+
+
+def setup_socket():
+    '''
+    Setup socket listener.
+    '''
+    skt = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    skt.bind(('127.0.0.1', int(sys.argv[1])))
+    skt.listen(1)
+    conn, addr = skt.accept()
+    data = conn.recv(1024)
+    conn.close()
+
+    with open(sys.argv[2], 'w') as dump:
+        dump.write(data)
+
+
+def daemonize(stdin="/dev/null", stdout="/dev/null", stderr="/dev/null"):
+    '''
+    Daemonize current script
+    '''
+    try: 
+        pid = os.fork() 
+        if pid > 0:
+            sys.exit(0)
+    except OSError, e: 
+        sys.stderr.write ("fork #1 failed: (%d) %s\n" % (e.errno, e.strerror) )
+        sys.exit(1)
+
+    os.chdir("/") 
+    os.umask(0) 
+    os.setsid() 
+
+    try: 
+        pid = os.fork() 
+        if pid > 0:
+            sys.exit(0)
+    except OSError, e: 
+        sys.stderr.write ("fork #2 failed: (%d) %s\n" % (e.errno, e.strerror) )
+        sys.exit(1)
+
+    stdin_par = os.path.dirname(stdin)
+    stdout_par = os.path.dirname(stdout)
+    stderr_par = os.path.dirname(stderr)
+    if not stdin_par:
+        os.path.makedirs(stdin_par)
+    if not stdout_par:
+        os.path.makedirs(stdout_par)
+    if not stderr_par:
+        os.path.makedirs(stderr_par)
+
+    si = open(stdin, 'r')
+    so = open(stdout, 'a+')
+    se = open(stderr, 'a+', 0)
+    os.dup2(si.fileno(), sys.stdin.fileno())
+    os.dup2(so.fileno(), sys.stdout.fileno())
+    os.dup2(se.fileno(), sys.stderr.fileno())
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 3:
+        print "Usage: {} port /path/to/output.file".format(os.path.basename(sys.argv[0]))
+        sys.exit(1)
+    else:
+        # This has to go background on its own,
+        # because shell tricks won't work :-(
+        daemonize()
+        setup_socket()

--- a/tests/ssh/conftest.py
+++ b/tests/ssh/conftest.py
@@ -61,7 +61,7 @@ def master(setup):
     def _cmd(master, cmd):
         SSH = "salt-ssh -i --out json --key-deploy --passwd {0} {1} {{0}}".format(
             PASSWORD, TARGET_ID)
-        return json.loads(
-            master['container'].run(SSH.format(cmd))).get(TARGET_ID)
+        out = master['container'].run(SSH.format(cmd))
+        return json.loads(out).get(TARGET_ID)
     master.salt_ssh = partial(_cmd, master)
     return master

--- a/tests/ssh/test_ssh.py
+++ b/tests/ssh/test_ssh.py
@@ -1,4 +1,6 @@
+import socket
 import pytest
+import multiprocessing
 from tests.common import GRAINS_EXPECTATIONS
 
 
@@ -105,3 +107,37 @@ def test_ssh_pkg_remove_sles(master):
     out = master.salt_ssh("pkg.remove test-package")
     assert out.get('test-package', {}).get('old')
     assert not out.get('test-package', {}).get('new')
+
+
+def socket_server(port, queue):
+    '''
+    Opens a local socket at specified port
+    '''
+    skt = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    skt.bind(('127.0.0.1', port))
+    skt.listen(1)
+    conn, addr = skt.accept()
+    data = conn.recv(1024)
+    conn.close()
+    queue.put('{"%s": "%s"}' % (addr[0], data))
+
+
+def test_ssh_port_forwarding(master):
+    '''
+    Test SSH port forwarding feature.
+    PR: https://github.com/saltstack/salt/pull/38021
+    '''
+    local_port = 8888
+    queue = multiprocessing.Queue()
+    srv = multiprocessing.Process(target=socket_server, args=(local_port, queue,))
+    srv.start()
+    
+    
+    netcat = master.salt_ssh("cmd.run 'zypper --non-interactive in netcat-openbsd'")
+    whichnc = master.salt_ssh("cmd.run 'which nc'")
+    isnetsend = master.salt_ssh("cmd.run 'file /salt-toaster/tests/scripts/netsend.sh'")
+    xxx = 'N/A'
+    if srv.is_alive():
+        xxx = master.salt_ssh("--remote-port-forwards=9999:127.0.0.1:8888 cmd.run '/salt-toaster/tests/scripts/netsend.sh foobar 9999'")
+
+    import pdb;pdb.set_trace()


### PR DESCRIPTION
It works this way:
1. Master runs a socket listener on `8888`.
2. Salt SSH sets up a port forwarding where everything from `9999` goes to `8888`.
3. Salt SSH sends a random message (just an SHA256 hexadecimal digest of the current time) to the port `9999`.
4. The socket listener grabs the data on the port `8888` and outputs to the file somewhere in `/tmp`
5. The data in the output file should be the same as the original message