### PR TITLE
Adding some new suse.tests to salt-toaster and Salt flavor tags

### DIFF
--- a/configs/suse.tests/rhel6/devel.cfg
+++ b/configs/suse.tests/rhel6/devel.cfg
@@ -1,0 +1,5 @@
+[pytest]
+addopts = --tb=short
+IMAGE = registry.mgr.suse.de/toaster-sles12sp1-devel
+MINION_IMAGE = registry.mgr.suse.de/toaster-rhel6-devel
+TAGS = rhel rhel6 devel

--- a/configs/suse.tests/rhel6/next.cfg
+++ b/configs/suse.tests/rhel6/next.cfg
@@ -2,4 +2,4 @@
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles12sp1-next
 MINION_IMAGE = registry.mgr.suse.de/toaster-rhel6-next
-TAGS = rhel rhel6
+TAGS = rhel rhel6 next

--- a/configs/suse.tests/rhel6/products-next.cfg
+++ b/configs/suse.tests/rhel6/products-next.cfg
@@ -2,4 +2,4 @@
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles12sp1-products-next
 MINION_IMAGE = registry.mgr.suse.de/toaster-rhel6-products-next
-TAGS = rhel rhel6
+TAGS = rhel rhel6 products-next

--- a/configs/suse.tests/rhel6/products-testing.cfg
+++ b/configs/suse.tests/rhel6/products-testing.cfg
@@ -2,4 +2,4 @@
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles12sp1-products-testing
 MINION_IMAGE = registry.mgr.suse.de/toaster-rhel6-products-testing
-TAGS = rhel rhel6
+TAGS = rhel rhel6 products-testing

--- a/configs/suse.tests/rhel6/products.cfg
+++ b/configs/suse.tests/rhel6/products.cfg
@@ -2,4 +2,4 @@
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles12sp1-products
 MINION_IMAGE = registry.mgr.suse.de/toaster-rhel6-products
-TAGS = rhel rhel6
+TAGS = rhel rhel6 products

--- a/configs/suse.tests/rhel6/testing.cfg
+++ b/configs/suse.tests/rhel6/testing.cfg
@@ -2,4 +2,4 @@
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles12sp1-testing
 MINION_IMAGE = registry.mgr.suse.de/toaster-rhel6-testing
-TAGS = rhel rhel6
+TAGS = rhel rhel6 testing

--- a/configs/suse.tests/rhel7/next.cfg
+++ b/configs/suse.tests/rhel7/next.cfg
@@ -2,4 +2,4 @@
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles12sp1-next
 MINION_IMAGE = registry.mgr.suse.de/toaster-rhel7-next
-TAGS = rhel rhel7
+TAGS = rhel rhel7 next

--- a/configs/suse.tests/rhel7/products-next.cfg
+++ b/configs/suse.tests/rhel7/products-next.cfg
@@ -2,4 +2,4 @@
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles12sp1-products-next
 MINION_IMAGE = registry.mgr.suse.de/toaster-rhel7-products-next
-TAGS = rhel rhel7
+TAGS = rhel rhel7 products-next

--- a/configs/suse.tests/rhel7/products-testing.cfg
+++ b/configs/suse.tests/rhel7/products-testing.cfg
@@ -2,4 +2,4 @@
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles12sp1-products-testing
 MINION_IMAGE = registry.mgr.suse.de/toaster-rhel7-products-testing
-TAGS = rhel rhel7
+TAGS = rhel rhel7 products-testing

--- a/configs/suse.tests/rhel7/products.cfg
+++ b/configs/suse.tests/rhel7/products.cfg
@@ -2,4 +2,4 @@
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles12sp1-products
 MINION_IMAGE = registry.mgr.suse.de/toaster-rhel7-products
-TAGS = rhel rhel7
+TAGS = rhel rhel7 products

--- a/configs/suse.tests/rhel7/testing.cfg
+++ b/configs/suse.tests/rhel7/testing.cfg
@@ -2,4 +2,4 @@
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles12sp1-testing
 MINION_IMAGE = registry.mgr.suse.de/toaster-rhel7-testing
-TAGS = rhel rhel7
+TAGS = rhel rhel7 testing

--- a/configs/suse.tests/sles11sp3/next.cfg
+++ b/configs/suse.tests/sles11sp3/next.cfg
@@ -1,4 +1,4 @@
 [pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles11sp3-next
-TAGS = sles sles11sp3
+TAGS = sles sles11sp3 next

--- a/configs/suse.tests/sles11sp3/products-next.cfg
+++ b/configs/suse.tests/sles11sp3/products-next.cfg
@@ -1,4 +1,4 @@
 [pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles11sp3-products-next
-TAGS = sles sles11sp3
+TAGS = sles sles11sp3 products-next

--- a/configs/suse.tests/sles11sp3/products-testing.cfg
+++ b/configs/suse.tests/sles11sp3/products-testing.cfg
@@ -1,4 +1,4 @@
 [pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles11sp3-products-testing
-TAGS = sles sles11sp3
+TAGS = sles sles11sp3 products-testing

--- a/configs/suse.tests/sles11sp3/products.cfg
+++ b/configs/suse.tests/sles11sp3/products.cfg
@@ -1,4 +1,4 @@
 [pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles11sp3-products
-TAGS = sles sles11sp3
+TAGS = sles sles11sp3 products

--- a/configs/suse.tests/sles11sp3/testing.cfg
+++ b/configs/suse.tests/sles11sp3/testing.cfg
@@ -1,4 +1,4 @@
 [pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles11sp3-testing
-TAGS = sles sles11sp3
+TAGS = sles sles11sp3 testing

--- a/configs/suse.tests/sles11sp4/next.cfg
+++ b/configs/suse.tests/sles11sp4/next.cfg
@@ -1,4 +1,4 @@
 [pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles11sp4-next
-TAGS = sles sles11sp4
+TAGS = sles sles11sp4 next

--- a/configs/suse.tests/sles11sp4/products-next.cfg
+++ b/configs/suse.tests/sles11sp4/products-next.cfg
@@ -1,4 +1,4 @@
 [pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles11sp4-products-next
-TAGS = sles sles11sp4
+TAGS = sles sles11sp4 products-next

--- a/configs/suse.tests/sles11sp4/products-testing.cfg
+++ b/configs/suse.tests/sles11sp4/products-testing.cfg
@@ -1,4 +1,4 @@
 [pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles11sp4-products-testing
-TAGS = sles sles11sp4
+TAGS = sles sles11sp4 products-testing

--- a/configs/suse.tests/sles11sp4/products.cfg
+++ b/configs/suse.tests/sles11sp4/products.cfg
@@ -1,4 +1,4 @@
 [pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles11sp4-products
-TAGS = sles sles11sp4
+TAGS = sles sles11sp4 products

--- a/configs/suse.tests/sles11sp4/testing.cfg
+++ b/configs/suse.tests/sles11sp4/testing.cfg
@@ -1,4 +1,4 @@
 [pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles11sp4-testing
-TAGS = sles sles11sp4
+TAGS = sles sles11sp4 testing

--- a/configs/suse.tests/sles12/next.cfg
+++ b/configs/suse.tests/sles12/next.cfg
@@ -1,4 +1,4 @@
 [pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles12-next
-TAGS = sles sles12
+TAGS = sles sles12 next

--- a/configs/suse.tests/sles12/products-next.cfg
+++ b/configs/suse.tests/sles12/products-next.cfg
@@ -1,4 +1,4 @@
 [pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles12-products-next
-TAGS = sles sles12
+TAGS = sles sles12 products-next

--- a/configs/suse.tests/sles12/products-testing.cfg
+++ b/configs/suse.tests/sles12/products-testing.cfg
@@ -1,4 +1,4 @@
 [pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles12-products-testing
-TAGS = sles sles12
+TAGS = sles sles12 products-testing

--- a/configs/suse.tests/sles12/products.cfg
+++ b/configs/suse.tests/sles12/products.cfg
@@ -1,4 +1,4 @@
 [pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles12-products
-TAGS = sles sles12
+TAGS = sles sles12 products

--- a/configs/suse.tests/sles12/testing.cfg
+++ b/configs/suse.tests/sles12/testing.cfg
@@ -1,4 +1,4 @@
 [pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles12-testing
-TAGS = sles sles12
+TAGS = sles sles12 testing

--- a/configs/suse.tests/sles12sp1/next.cfg
+++ b/configs/suse.tests/sles12sp1/next.cfg
@@ -1,4 +1,4 @@
 [pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles12sp1-next
-TAGS = sles sles12sp1
+TAGS = sles sles12sp1 next

--- a/configs/suse.tests/sles12sp1/products-next.cfg
+++ b/configs/suse.tests/sles12sp1/products-next.cfg
@@ -1,4 +1,4 @@
 [pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles12sp1-products-next
-TAGS = sles sles12sp1
+TAGS = sles sles12sp1 products-next

--- a/configs/suse.tests/sles12sp1/products-testing.cfg
+++ b/configs/suse.tests/sles12sp1/products-testing.cfg
@@ -1,4 +1,4 @@
 [pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles12sp1-products-testing
-TAGS = sles sles12sp1
+TAGS = sles sles12sp1 products-testing

--- a/configs/suse.tests/sles12sp1/products.cfg
+++ b/configs/suse.tests/sles12sp1/products.cfg
@@ -1,4 +1,4 @@
 [pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles12sp1-products
-TAGS = sles sles12sp1
+TAGS = sles sles12sp1 products

--- a/configs/suse.tests/sles12sp1/testing.cfg
+++ b/configs/suse.tests/sles12sp1/testing.cfg
@@ -1,4 +1,4 @@
 [pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles12sp1-testing
-TAGS = sles sles12sp1
+TAGS = sles sles12sp1 testing

--- a/configs/suse.tests/sles12sp2/next.cfg
+++ b/configs/suse.tests/sles12sp2/next.cfg
@@ -1,4 +1,4 @@
 [pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles12sp2-next
-TAGS = sles sles12sp2
+TAGS = sles sles12sp2 next

--- a/configs/suse.tests/sles12sp2/products-next.cfg
+++ b/configs/suse.tests/sles12sp2/products-next.cfg
@@ -1,4 +1,4 @@
 [pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles12sp2-products-next
-TAGS = sles sles12sp2
+TAGS = sles sles12sp2 products-next

--- a/configs/suse.tests/sles12sp2/products-testing.cfg
+++ b/configs/suse.tests/sles12sp2/products-testing.cfg
@@ -1,4 +1,4 @@
 [pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles12sp2-products-testing
-TAGS = sles sles12sp2
+TAGS = sles sles12sp2 products-testing

--- a/configs/suse.tests/sles12sp2/products.cfg
+++ b/configs/suse.tests/sles12sp2/products.cfg
@@ -1,4 +1,4 @@
 [pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles12sp2-products
-TAGS = sles sles12sp2
+TAGS = sles sles12sp2 products

--- a/configs/suse.tests/sles12sp2/testing.cfg
+++ b/configs/suse.tests/sles12sp2/testing.cfg
@@ -1,4 +1,4 @@
 [pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles12sp2-testing
-TAGS = sles sles12sp2
+TAGS = sles sles12sp2 testing

--- a/tests/sls/downloaded.sls
+++ b/tests/sls/downloaded.sls
@@ -1,0 +1,4 @@
+test-pkg-downloaded:
+  pkg.installed:
+    - name: test-package
+    - downloadonly: True

--- a/tests/sls/patches-downloaded.sls
+++ b/tests/sls/patches-downloaded.sls
@@ -1,0 +1,7 @@
+test-patches-downloaded:
+  pkg.installed:
+    - downloadonly: True
+    - patches:
+{% for patch in pillar.get('patches', []) %}
+      - {{ patch }}
+{% endfor %}

--- a/tests/test_pkg.py
+++ b/tests/test_pkg.py
@@ -94,3 +94,11 @@ def test_pkg_info_build_date(minion, timezone):
         res['test-package']['build_date'], "%Y-%m-%dT%H:%M:%SZ")
     timestamp = (dt - datetime.datetime(1970, 1, 1)).total_seconds()
     assert int(timestamp) == int(res['test-package']['build_date_time_t'])
+
+
+def test_pkg_install_downloadonly(minion):
+    list_pkgs_pre = minion.salt_call('pkg.list_pkgs')
+    res = minion.salt_call('pkg.install', 'test-package downloadonly=True')
+    list_pkgs_post = minion.salt_call('pkg.list_pkgs')
+    assert res == {}
+    assert list_pkgs_pre == list_pkgs_post

--- a/tests/test_states.py
+++ b/tests/test_states.py
@@ -1,4 +1,5 @@
 import pytest
+import os
 
 
 @pytest.fixture(scope='module')
@@ -9,7 +10,9 @@ def module_config(request):
                 'config': {
                     'container__config__salt_config__sls': {
                         'latest': 'tests/sls/latest.sls',
-                        'latest-again': 'tests/sls/latest-again.sls'
+                        'latest-again': 'tests/sls/latest-again.sls',
+                        'downloaded': 'tests/sls/downloaded.sls',
+                        'patches-downloaded': 'tests/sls/patches-downloaded.sls'
                     }
                 },
                 'minions': [{'config': {}}, {'config': {}}]
@@ -34,3 +37,47 @@ def test_pkg_latest_version_already_installed(setup):
     resp = master['fixture'].salt(minion['id'], 'state.apply latest-again')
     assert resp[minion['id']][
         'pkg_|-latest-version_|-test-package_|-latest']['result'] is True
+
+
+def test_pkg_installed_downloadonly(setup):
+    config, initconfig = setup
+    master = config['masters'][0]
+    minion = master['minions'][0]
+    list_pkgs_pre = master['fixture'].salt(minion['id'], 'pkg.list_pkgs')
+    resp = master['fixture'].salt(minion['id'], 'state.apply downloaded')
+    list_pkgs_post = master['fixture'].salt(minion['id'], 'pkg.list_pkgs')
+    assert resp[minion['id']][
+        'pkg_|-test-pkg-downloaded_|-test-package_|-installed']['result'] is True
+    assert list_pkgs_pre == list_pkgs_post
+
+
+@pytest.mark.tags('sles')
+def test_patches_installed_downloadonly_sles(setup):
+    config, initconfig = setup
+    master = config['masters'][0]
+    minion = master['minions'][0]
+    patches = master['fixture'].salt(minion['id'],
+        'cmd.run "zypper --quiet patches | cut -d\'|\' -f2 | cut -d\' \' -f2"'
+        )[minion['id']].encode('utf-8').split(os.linesep)
+    patches = {"patches": filter(lambda x: "SUSE-SLE-SERVER" in x, patches)[:2]}
+    list_pkgs_pre = master['fixture'].salt(minion['id'], 'pkg.list_pkgs')
+    resp = master['fixture'].salt(minion['id'], 'state.apply patches-downloaded pillar=\'{0}\''.format(patches))
+    list_pkgs_post = master['fixture'].salt(minion['id'], 'pkg.list_pkgs')
+    assert resp[minion['id']]['pkg_|-test-patches-downloaded_|-test-patches-downloaded_|-installed']['result'] is True
+    assert list_pkgs_pre == list_pkgs_post
+
+
+@pytest.mark.tags('rhel')
+def test_patches_installed_downloadonly_rhel(setup):
+    config, initconfig = setup
+    master = config['masters'][0]
+    minion = master['minions'][0]
+    patches = master['fixture'].salt(minion['id'],
+        'cmd.run "yum info-sec | grep \'Update ID\' | cut -d\' \' -f6"'
+        )[minion['id']].encode('utf-8').split(os.linesep)
+    patches = {"patches": filter(lambda x: "RHBA" in x, patches)[:2]}
+    list_pkgs_pre = master['fixture'].salt(minion['id'], 'pkg.list_pkgs')
+    resp = master['fixture'].salt(minion['id'], 'state.apply patches-downloaded pillar=\'{0}\''.format(patches))
+    list_pkgs_post = master['fixture'].salt(minion['id'], 'pkg.list_pkgs')
+    assert resp[minion['id']]['pkg_|-test-patches-downloaded_|-test-patches-downloaded_|-installed']['result'] is True
+    assert list_pkgs_pre == list_pkgs_post


### PR DESCRIPTION
This PR adds some new suse.tests:

1. `test_pkg_install_downloadonly`
2. `test_pkg_installed_downloadonly`
3. `test_patches_installed_downloadonly_sles`
4. `test_patches_installed_downloadonly_rhel`
5. `test_timeout_and_gather_job_timeout`

Also adds Salt flavor pytest tags to be used in case some suse.tests is flavor dependent.

We should wait before merging until discussion on [this upstream Salt PR](https://github.com/saltstack/salt/pull/40266) is finished and final patches are included in our Salt packages.

UPDATE:
Upstream PR is not merged yet but we accepted those changes into our Salt package. If upstream PR finally changes before merging we will update that patch in our Salt package + these tests if necessary.