### PR TITLE
Add junit support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ ifndef NOPULL
 endif
 
 PYTEST_ARGS=-c $(PYTEST_CFG) $(SALT_TESTS) $(PYTEST_FLAGS)
-CMD=pytest $(PYTEST_ARGS)
+CMD=pytest $(PYTEST_ARGS) --junitxml results.xml
 EXEC=docker run $(EXPORTS) -e "CMD=$(CMD)" --rm $(DOCKER_VOLUMES) $(DOCKER_IMAGE) tests
 
 ifndef RPDB_PORT


### PR DESCRIPTION
## description:

we will benifts for more sorting and  benifits for toaster.
Jenkins will give more meta-info about junit

## change for users:

for users we don't have any changes 


## need to do on jenkins-side:

- [ ] we need to export the file to the workspace then we are fine :rocket: 

@meaksh @dincamihai @brejoc 

I think we can change 'results.xml' to 'toaster_results.xml' or open for other names :rabbit: :smile: 