### PR TITLE
Adds resource limits for Docker run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,11 +46,11 @@ ifndef DOCKER_FILE
 endif
 
 ifdef DOCKER_MEM
-	DOCKER_RES_LIMITS = --mem="$DOCKER_MEM"
+	DOCKER_RES_LIMITS = --memory="$(DOCKER_MEM)"
 endif
 
 ifdef DOCKER_CPUS
-	DOCKER_RES_LIMITS := $DOCKER_RES_LIMITS --cpus="$DOCKER_CPUS"
+	DOCKER_RES_LIMITS := $(DOCKER_RES_LIMITS) --cpus="$(DOCKER_CPUS)"
 endif
 
 # Setting the defaults for a job execution in Jenkins
@@ -83,12 +83,12 @@ endif
 
 PYTEST_ARGS=-c $(PYTEST_CFG) $(SALT_TESTS) $(PYTEST_FLAGS)
 CMD=pytest $(PYTEST_ARGS) --junitxml results.xml
-EXEC=docker run $(EXPORTS) $(DOCKER_RES_LIMITS) -e "CMD=$(CMD)" --rm $(DOCKER_VOLUMES) $(DOCKER_IMAGE) tests
+EXEC=docker run $(EXPORTS) -e "CMD=$(CMD)" --rm $(DOCKER_VOLUMES) $(DOCKER_RES_LIMITS) $(DOCKER_IMAGE) tests
 
 ifndef RPDB_PORT
-docker_shell : EXEC=docker run -it $(EXPORTS) $(DOCKER_RES_LIMITS) -e "CMD=$(CMD)" --rm $(DOCKER_VOLUMES) $(DOCKER_IMAGE)
+docker_shell : EXEC=docker run -it $(EXPORTS) -e "CMD=$(CMD)" --rm $(DOCKER_VOLUMES) $(DOCKER_RES_LIMITS) $(DOCKER_IMAGE)
 else
-docker_shell : EXEC=docker run -p $(RPDB_PORT):4444 -it $(EXPORTS) $(DOCKER_RES_LIMITS) -e "CMD=$(CMD)" --rm $(DOCKER_VOLUMES) $(DOCKER_IMAGE)
+docker_shell : EXEC=docker run -p $(RPDB_PORT):4444 -it $(EXPORTS) -e "CMD=$(CMD)" --rm $(DOCKER_VOLUMES) $(DOCKER_RES_LIMITS) $(DOCKER_IMAGE)
 endif
 docker_shell : CMD=/bin/bash
 docker_shell :: pull_image

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,13 @@ ifdef DOCKER_CPUS
 	DOCKER_RES_LIMITS := $DOCKER_RES_LIMITS --cpus="$DOCKER_CPUS"
 endif
 
+# Setting the defaults for a job execution in Jenkins
+ifdef BUILD_ID
+ifndef DOCKER_RES_LIMITS
+	DOCKER_RES_LIMITS := --mem="2G" --cpus="1.5"
+endif
+endif
+
 help:
 	@echo "Salt Toaster: an ultimate test suite for Salt."
 	@echo

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,14 @@ ifndef DOCKER_FILE
 	DOCKER_FILE = Dockerfile.$(VERSION).$(FLAVOR)
 endif
 
+ifdef DOCKER_MEM
+	DOCKER_RES_LIMITS = --mem="$DOCKER_MEM"
+endif
+
+ifdef DOCKER_CPUS
+	DOCKER_RES_LIMITS := $DOCKER_RES_LIMITS --cpus="$DOCKER_CPUS"
+endif
+
 help:
 	@echo "Salt Toaster: an ultimate test suite for Salt."
 	@echo
@@ -68,12 +76,12 @@ endif
 
 PYTEST_ARGS=-c $(PYTEST_CFG) $(SALT_TESTS) $(PYTEST_FLAGS)
 CMD=pytest $(PYTEST_ARGS) --junitxml results.xml
-EXEC=docker run $(EXPORTS) -e "CMD=$(CMD)" --rm $(DOCKER_VOLUMES) $(DOCKER_IMAGE) tests
+EXEC=docker run $(EXPORTS) $(DOCKER_RES_LIMITS) -e "CMD=$(CMD)" --rm $(DOCKER_VOLUMES) $(DOCKER_IMAGE) tests
 
 ifndef RPDB_PORT
-docker_shell : EXEC=docker run -it $(EXPORTS) -e "CMD=$(CMD)" --rm $(DOCKER_VOLUMES) $(DOCKER_IMAGE)
+docker_shell : EXEC=docker run -it $(EXPORTS) $(DOCKER_RES_LIMITS) -e "CMD=$(CMD)" --rm $(DOCKER_VOLUMES) $(DOCKER_IMAGE)
 else
-docker_shell : EXEC=docker run -p $(RPDB_PORT):4444 -it $(EXPORTS) -e "CMD=$(CMD)" --rm $(DOCKER_VOLUMES) $(DOCKER_IMAGE)
+docker_shell : EXEC=docker run -p $(RPDB_PORT):4444 -it $(EXPORTS) $(DOCKER_RES_LIMITS) -e "CMD=$(CMD)" --rm $(DOCKER_VOLUMES) $(DOCKER_IMAGE)
 endif
 docker_shell : CMD=/bin/bash
 docker_shell :: pull_image

--- a/README.adoc
+++ b/README.adoc
@@ -167,6 +167,12 @@ When running the `saltstack.unit` or `saltstack.integration`, `SALT_TESTS` must 
 | FLAVOR  | products, products-testing, products-next, devel
 |===
 
+.DOCKER_CPUS and DOCKER_MEM
+
+With these two parameters you can limit the resouce usage of the spun up Docker container. Examples would be `2G` or `512M` for `DOCKER_MEM` and `1` or `2.5` for `DOCKER_CPUS`. Where the number provided for `DOCKER_CPUS` would the number of host CPUs the container should able to use.
+
+Please take a look at the official https://docs.docker.com/config/containers/resource_constraints/[Docker documentation] for more information about https://docs.docker.com/config/containers/resource_constraints/#limit-a-containers-access-to-memory[DOCKER_MEM] and https://docs.docker.com/config/containers/resource_constraints/#cpu[DOCKER_CPUS]
+
 
 == Ignore/Xfail upstream tests
 


### PR DESCRIPTION
The Makefile now takes two additional parameters: DOCKER_MEM and DOCKER_CPUS

DOCKER_MEM allows to limit the available memory usage.
https://docs.docker.com/config/containers/resource_constraints/#limit-a-containers-access-to-memory

DOCKER_CPUS limits the CPU resources a container can use.
https://docs.docker.com/config/containers/resource_constraints/#cpu