### PR TITLE
Create cProfile from pytest execution and export metrics to Prometheus node exporter

### DIFF
--- a/reports/.gitignore
+++ b/reports/.gitignore
@@ -1,1 +1,3 @@
 *.xml
+*.prof
+*.json

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -136,24 +136,24 @@ class ToasterTestsProfiling(object):
 
     def process_stats(self):  # @UnusedVariable
         timings = {
-            'runtest_setup_value': 0,
-            'runtest_call_value': 0,
-            'runtest_teardown_value': 0
+            'pytest_runtest_setup_value': 0,
+            'pytest_runtest_call_value': 0,
+            'pytest_runtest_teardown_value': 0
         }
         stream = StringIO.StringIO()
         stats = pstats.Stats(PROFILE_RESULTS_FILE, stream=stream)
-        stats.sort_stats('cumulative').print_stats('runtest_setup', 1)
-        stats.sort_stats('cumulative').print_stats('runtest_call', 1)
-        stats.sort_stats('cumulative').print_stats('runtest_teardown', 1)
+        stats.sort_stats('cumulative').print_stats('pytest_runtest_setup', 1)
+        stats.sort_stats('cumulative').print_stats('pytest_runtest_call', 1)
+        stats.sort_stats('cumulative').print_stats('pytest_runtest_teardown', 1)
         for line in stream.getvalue().split('\n'):
             if re.match('.+\d+.+\d+\.\d+.+\d+\.\d+.+\d+\.\d+.+\d+\.\d+.*', line):
                 line_list = [item for item in line.split(' ') if item]
-                if 'runtest_setup' in line:
-                   timings['runtest_setup_value'] = float(line_list[3])
-                elif 'runtest_call' in line:
-                   timings['runtest_call_value'] = float(line_list[3])
-                elif 'runtest_teardown' in line:
-                   timings['runtest_teardown_value'] = float(line_list[3])
+                if 'pytest_runtest_setup' in line:
+                   timings['pytest_runtest_setup_value'] = float(line_list[3])
+                elif 'pytest_runtest_call' in line:
+                   timings['pytest_runtest_call_value'] = float(line_list[3])
+                elif 'pytest_runtest_teardown' in line:
+                   timings['pytest_runtest_teardown_value'] = float(line_list[3])
         self.accumulate_values_to_json(timings, TOASTER_TIMINGS_JSON)
 
     def pytest_terminal_summary(self, terminalreporter):
@@ -163,9 +163,9 @@ class ToasterTestsProfiling(object):
             "generated cProfile stats file on: {}".format(PROFILE_RESULTS_FILE))
         terminalreporter.write_sep("-", "Salt Toaster Profiling Stats")
         stats = pstats.Stats(self.global_profile, stream=terminalreporter)
-        stats.sort_stats('cumulative').print_stats('runtest_setup', 1)
-        stats.sort_stats('cumulative').print_stats('runtest_call', 1)
-        stats.sort_stats('cumulative').print_stats('runtest_teardown', 1)
+        stats.sort_stats('cumulative').print_stats('pytest_runtest_setup', 1)
+        stats.sort_stats('cumulative').print_stats('pytest_runtest_call', 1)
+        stats.sort_stats('cumulative').print_stats('pytest_runtest_teardown', 1)
         self.process_stats()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -155,7 +155,7 @@ class ToasterTestsProfiling(object):
         stats.sort_stats('cumulative').print_stats('runtest_call', 1)
         stats.sort_stats('cumulative').print_stats('runtest_teardown', 1)
         for line in stream.getvalue().split('\n'):
-            if re.match('.+\d+.+\d+\.\d+.+\d+\.\d+.+\d+\.\d+.+\d\.\d+.*', line):
+            if re.match('.+\d+.+\d+\.\d+.+\d+\.\d+.+\d+\.\d+.+\d+\.\d+.*', line):
                 line_list = [item for item in line.split(' ') if item]
                 if 'runtest_setup' in line:
                    timings['runtest_setup_value'] = float(line_list[3])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,8 +112,6 @@ def minion(setup):
 class ToasterTestsProfiling(object):
     """Toaster Tests Profiling plugin for pytest."""
 
-    tests_profs = []
-    docker_profs = []
     global_profile = None
 
     def __init__(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -150,7 +150,7 @@ node_salt_toaster{{step="pytest_runtest_teardown"}} {pytest_runtest_teardown}
                     ).strip()
                 )
         except IOError as exc:
-            log.error("Failed to export metrics to Prometheus node " \
+            logger.error("Failed to export metrics to Prometheus node " \
                 "exporter file {}: {}".format(NODE_EXPORTER_METRIC_FILE, exc))
 
     def process_stats(self):  # @UnusedVariable

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -149,7 +149,7 @@ node_salt_toaster{{step="pytest_runtest_teardown"}} {pytest_runtest_teardown}
                         pytest_runtest_setup=values['pytest_runtest_setup'],
                         pytest_runtest_call=values['pytest_runtest_call'],
                         pytest_runtest_teardown=values['pytest_runtest_teardown'],
-                    )
+                    ).strip()
                 )
         except IOError as exc:
             log.error("Failed to export metrics to Prometheus node " \

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,16 +134,7 @@ class ToasterTestsProfiling(object):
         with open(json_filename, 'w') as outfile:
             json.dump(values, outfile)
 
-    def pytest_terminal_summary(self, terminalreporter):
-        self.global_profile.disable()
-        self.global_profile.dump_stats(PROFILE_RESULTS_FILE)
-        terminalreporter.write("--------------------- Salt Toaster Profiling Stats ---------------------\n")
-        stats = pstats.Stats(self.global_profile, stream=terminalreporter)
-        stats.sort_stats('cumulative').print_stats('runtest_setup', 1)
-        stats.sort_stats('cumulative').print_stats('runtest_call', 1)
-        stats.sort_stats('cumulative').print_stats('runtest_teardown', 1)
-
-    def pytest_sessionfinish(self, session):  # @UnusedVariable
+    def process_stats(self):  # @UnusedVariable
         timings = {
             'runtest_setup_value': 0,
             'runtest_call_value': 0,
@@ -164,6 +155,18 @@ class ToasterTestsProfiling(object):
                 elif 'runtest_teardown' in line:
                    timings['runtest_teardown_value'] = float(line_list[3])
         self.accumulate_values_to_json(timings, TOASTER_TIMINGS_JSON)
+
+    def pytest_terminal_summary(self, terminalreporter):
+        self.global_profile.disable()
+        self.global_profile.dump_stats(PROFILE_RESULTS_FILE)
+        terminalreporter.write_sep("-",
+            "generated cProfile stats file on: {}".format(PROFILE_RESULTS_FILE))
+        terminalreporter.write_sep("-", "Salt Toaster Profiling Stats")
+        stats = pstats.Stats(self.global_profile, stream=terminalreporter)
+        stats.sort_stats('cumulative').print_stats('runtest_setup', 1)
+        stats.sort_stats('cumulative').print_stats('runtest_call', 1)
+        stats.sort_stats('cumulative').print_stats('runtest_teardown', 1)
+        self.process_stats()
 
 
 def pytest_configure(config):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -147,7 +147,7 @@ node_salt_toaster{{step="pytest_runtest_teardown"}} {pytest_runtest_teardown}
                         pytest_runtest_setup=values['pytest_runtest_setup'],
                         pytest_runtest_call=values['pytest_runtest_call'],
                         pytest_runtest_teardown=values['pytest_runtest_teardown'],
-                    ).strip()
+                    ).lstrip()
                 )
         except IOError as exc:
             logger.error("Failed to export metrics to Prometheus node " \

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,17 +118,20 @@ class ToasterTestsProfiling(object):
         self.global_profile = cProfile.Profile()
         self.global_profile.enable()
 
-    def accumulate_values_to_json(values, json_filename):
+    def accumulate_values_to_json(self, values, json_filename):
         output = {}
         # Read possible values on the file
-        with open(json_filename) as infile:
-            output = json.load(infile)
+        try:
+            with open(json_filename) as infile:
+                output = json.load(infile)
+        except IOError:
+            pass
 
         # Accumulate current values with older ones
         for item in output.keys():
             values[item] += output[item]
 
-        with open(json_filename) as outfile:
+        with open(json_filename, 'w') as outfile:
             json.dump(values, outfile)
 
     def pytest_terminal_summary(self, terminalreporter):
@@ -160,7 +163,7 @@ class ToasterTestsProfiling(object):
                    timings['runtest_call_value'] = float(line_list[3])
                 elif 'runtest_teardown' in line:
                    timings['runtest_teardown_value'] = float(line_list[3])
-        accumulate_values_to_json(timings, TOASTER_TIMINGS_JSON)
+        self.accumulate_values_to_json(timings, TOASTER_TIMINGS_JSON)
 
 
 def pytest_configure(config):


### PR DESCRIPTION
This PR creates a cProfile containing all stats from the pytest execution. 

- Store the full cProfile profile into `reports/global.prof` file after pytest execution.
- Save "accumulated" values from previous runs on `reports/toaster-timings.json`.
- Export metrics to Prometheus via node exporter: `/var/lib/node_exporter/textfile_collector/salt_toaster.prom`

Current calculated metrics are (exported as accumulated values):

- "pytest_runtest_setup" -- Tests preparation time (fixtures, creating containers, etc).
- "pytest_runtest_call" -- Actual tests execution time.
- "pytest_runtest_teardown" -- Tests teardown time (cleaning up, removing containers, etc).
