### PR TITLE
Use a SLES15 specific pytest configuration file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,11 @@ docker_shell : CMD=/bin/bash
 docker_shell :: pull_image
 	$(EXEC)
 
+ifeq ("$(VERSION)", "sles15")
+saltstack.unit : PYTEST_CFG=./configs/saltstack.unit/sles15.cfg
+else
 saltstack.unit : PYTEST_CFG=./configs/saltstack.unit/common.cfg
+endif
 ifneq ("$(FLAVOR)", "devel")
 ifdef JENKINS_HOME
 saltstack.unit : PYTEST_ARGS:=$(PYTEST_ARGS) --timeout=500
@@ -107,7 +111,11 @@ endif
 saltstack.unit :: pull_image
 	$(EXEC)
 
+ifeq ("$(VERSION)", "sles15")
+saltstack.integration : PYTEST_CFG=./configs/saltstack.integration/sles15.cfg
+else
 saltstack.integration : PYTEST_CFG=./configs/saltstack.integration/common.cfg
+endif
 ifneq ("$(FLAVOR)", "devel")
 ifdef JENKINS_HOME
 saltstack.integration : PYTEST_ARGS:=$(PYTEST_ARGS) --timeout=500

--- a/configs/saltstack.integration/sles15.cfg
+++ b/configs/saltstack.integration/sles15.cfg
@@ -1,0 +1,9 @@
+[tool:pytest]
+addopts = -v --tb=line
+
+usefixtures = salt_test_daemon
+
+python_files =
+    integration/*
+
+tests_type = integration

--- a/configs/saltstack.unit/sles15.cfg
+++ b/configs/saltstack.unit/sles15.cfg
@@ -1,0 +1,9 @@
+[tool:pytest]
+addopts = -v --tb=line
+
+usefixtures = transplant_configs
+
+python_files =
+    unit/*
+
+tests_type = unit

--- a/configs/suse.tests/sles15/products-next.cfg
+++ b/configs/suse.tests/sles15/products-next.cfg
@@ -1,4 +1,4 @@
-[pytest]
+[tool:pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles15-products-next
 TAGS = sles sles15 products-next salt-2018.3.0

--- a/configs/suse.tests/sles15/unstable.cfg
+++ b/configs/suse.tests/sles15/unstable.cfg
@@ -1,4 +1,4 @@
-[pytest]
+[tool:pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles15-unstable
 TAGS = sles sles15 unstable


### PR DESCRIPTION
This PR fixes the salt-toaster issues after reverting https://github.com/openSUSE/salt-toaster/commit/29a1155472e0782308bc26f385cf25f789420d96 (which was reverted because pytest on python2.6 systems doesn't accept the new `[tool:pytest]` header).

So, this PR set a SLE15 specific configuration file to use the new header format and to keep the old format for older systems.

/cc @dincamihai 