### PR TITLE
Do not exclude 'integration/__init__.py' so tests can run on SLE15

### DIFF
--- a/conftest.py.source
+++ b/conftest.py.source
@@ -20,7 +20,6 @@ KNOWN_ISSUES_INTEGRATION = {
             'integration/modules/git.py',
             'integration/cloud/helpers/virtualbox.py',
 
-            'integration/__init__.py',
             'integration/utils/*',
 
             # Running following tests causes unsuccessfully close


### PR DESCRIPTION
The `integration/__init__.py` file was added to the ignore_list back in 2017 (for "products-next") but now this is causing an issue when running `pytest` that produces no tests are collected on SLE15:

```
timeout 180m pytest -c ./configs/saltstack.integration/sles15.cfg /salt/src/salt-*/tests  --timeout=500 --junitxml results.xml
============================= test session starts ==============================
platform linux -- Python 3.6.5, pytest-3.9.2, py-1.5.3, pluggy-0.8.0 -- /usr/bin/python3
cachedir: .pytest_cache
tempdir: /tmp/salt-toaster
rootdir: /salt/src/salt-2018.3.0/tests, inifile: ./configs/saltstack.integration/sles15.cfg
plugins: timeout-1.3.2, tempdir-2016.8.20, salt-2018.9.28, helpers-namespace-2017.11.11, catchlog-1.2.2
timeout: 500.0s
timeout method: signal
timeout func_only: False
collecting ... collected 0 items

---------------- generated xml file: /salt-toaster/results.xml -----------------
=============================== warnings summary ===============================
  pytest-catchlog plugin has been merged into the core, please remove it from your requirements.

-- Docs: https://docs.pytest.org/en/latest/warnings.html
========================== 1 warnings in 2.18 seconds ==========================
make: *** [/root/Makefile:15: default] Error 5
```

https://ci.suse.de/user/manager/my-views/view/Salt/view/default/job/manager-products-testing-saltstack-integration-sles15/496/console

Integration tests for SLE15 are now running after removing `integration/__init__.py` from the ignore list.
