### PR TITLE
Prevent failure on pytest 4.0.0 because getfuncargvalue deprecation

### DIFF
--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -56,8 +56,8 @@ def pytest_generate_tests(metafunc):
 @pytest.fixture()
 def test_container(request):
     params = {
-        'master': partial(request.getfuncargvalue, 'master_container'),
-        'minion': partial(request.getfuncargvalue, 'minion_container')
+        'master': partial(request.getfixturevalue, 'master_container'),
+        'minion': partial(request.getfixturevalue, 'minion_container')
     }
     return params[request.param]()
 


### PR DESCRIPTION
After latest update of pytest to 4.0.0 we're reaching errors [1] during `suse.tests` execution because `getfuncargvalue` function has been deprecated:

https://ci.suse.de/user/manager/my-views/view/Salt/view/default/job/manager-products-old-testing-suse-integration-sles11sp4/341/console

This PR makes use of the suggested alternative: `getfixturevalue` to make tests works.