### PR TITLE
Provide default for ST_JOB_ID

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,10 @@ DOCKER_VOLUMES        = -v "$(CURDIR)/:$(TOASTER_MOUNTPOINT)"
 DESTRUCTIVE_TESTS     = False
 EXPENSIVE_TESTS       = False
 
+ifndef ST_JOB_ID
+	export ST_JOB_ID = "local-test-run"
+endif
+
 ifndef VERSION
 	VERSION = $(DEFAULT_VERSION)
 endif


### PR DESCRIPTION
With a fresh installation there is no env. variable for `ST_JOB_ID` and we get a misleading error from Docker that `--label` cannot be empty.

By default `ST_JOB_ID` is now set to 'local-test-run' if nothing else is provided.

Closes  #75