### PR TITLE
Added Python3 details and cert path for TW

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -76,6 +76,13 @@ openSUSE system:
 sudo zypper in docker python python-virtualenv make
 ----
 
+openSUSE system with Python3:
+
+[source,bash]
+----
+sudo zypper in docker python3 python3-virtualenv make
+----
+
 Debian system:
 Your systems need to have docker and docker.io pkg installed
 

--- a/README_SUSE.adoc
+++ b/README_SUSE.adoc
@@ -42,7 +42,7 @@ sudo update-ca-certificates
 sudo systemctl restart docker
 ----
 
-At least for Tumbleweed it might be enough to copy the certificat to `/etc/docker/certs.d/registry.mgr.suse.de/` and then run:
+At least for Tumbleweed it might be enough to copy the certificate to `/etc/docker/certs.d/registry.mgr.suse.de/` and then run:
 
 [source,bash]
 ----

--- a/README_SUSE.adoc
+++ b/README_SUSE.adoc
@@ -41,3 +41,10 @@ And run:
 sudo update-ca-certificates
 sudo systemctl restart docker
 ----
+
+At least for Tumbleweed it might be enough to copy the certificat to `/etc/docker/certs.d/registry.mgr.suse.de/` and then run:
+
+[source,bash]
+----
+sudo systemctl restart docker
+----


### PR DESCRIPTION
For Python3 systems the packages need to be different and Tumbleweeds seems to accept the cert in a different place.