### PR TITLE
Drop Python2 instructions for openSUSE

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -69,13 +69,6 @@ For the suse tests, the approach is different. `py.test` is being run on the hos
 
 === Prerequisites:
 
-openSUSE system:
-
-[source,bash]
-----
-sudo zypper in docker python python-virtualenv make
-----
-
 openSUSE system with Python3:
 
 [source,bash]


### PR DESCRIPTION
We don't need instructions for both Python2 and Python3 for openSUSE
systems, all openSUSE distros come with Python3.