### PR TITLE
Add missing SLES15 config files for products

### DIFF
--- a/configs/suse.tests/leap15/devel.cfg
+++ b/configs/suse.tests/leap15/devel.cfg
@@ -2,4 +2,4 @@
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles15-devel
 MINION_IMAGE = registry.mgr.suse.de/toaster-sles15-devel
-TAGS = sles sles15 devel 2018.3.2
+TAGS = sles sles15 devel

--- a/configs/suse.tests/opensuse150/devel.cfg
+++ b/configs/suse.tests/opensuse150/devel.cfg
@@ -2,4 +2,4 @@
 addopts = --tb=short
 IMAGE = salttoaster/toaster-opensuse150-devel
 MINION_IMAGE = salttoaster/toaster-opensuse150-devel
-TAGS = opensuse opensuse150 devel 3000.3
+TAGS = opensuse opensuse150 devel

--- a/configs/suse.tests/opensuse150/devel.cfg
+++ b/configs/suse.tests/opensuse150/devel.cfg
@@ -2,4 +2,4 @@
 addopts = --tb=short
 IMAGE = salttoaster/toaster-opensuse150-devel
 MINION_IMAGE = salttoaster/toaster-opensuse150-devel
-TAGS = opensuse opensuse150 devel 2019.2.0
+TAGS = opensuse opensuse150 devel 3000.3

--- a/configs/suse.tests/opensuse151/devel.cfg
+++ b/configs/suse.tests/opensuse151/devel.cfg
@@ -2,4 +2,4 @@
 addopts = --tb=short
 IMAGE = salttoaster/toaster-opensuse151-devel
 MINION_IMAGE = salttoaster/toaster-opensuse151-devel
-TAGS = opensuse opensuse151 devel 3000.3
+TAGS = opensuse opensuse151 devel

--- a/configs/suse.tests/opensuse151/devel.cfg
+++ b/configs/suse.tests/opensuse151/devel.cfg
@@ -2,4 +2,4 @@
 addopts = --tb=short
 IMAGE = salttoaster/toaster-opensuse151-devel
 MINION_IMAGE = salttoaster/toaster-opensuse151-devel
-TAGS = opensuse opensuse151 devel 2019.2.0
+TAGS = opensuse opensuse151 devel 3000.3

--- a/configs/suse.tests/opensuse423/devel.cfg
+++ b/configs/suse.tests/opensuse423/devel.cfg
@@ -2,4 +2,4 @@
 addopts = --tb=short
 IMAGE = salttoaster/toaster-opensuse423-devel
 MINION_IMAGE = salttoaster/toaster-opensuse423-devel
-TAGS = opensuse opensuse423 devel 2019.2.0
+TAGS = opensuse opensuse423 devel

--- a/configs/suse.tests/rhel7/products-next-testing.cfg
+++ b/configs/suse.tests/rhel7/products-next-testing.cfg
@@ -2,4 +2,4 @@
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles12sp3-products-next-testing
 MINION_IMAGE = registry.mgr.suse.de/toaster-rhel7-products-next-testing
-TAGS = rhel rhel7 products-next-testing salt-3000.3
+TAGS = rhel rhel7 products-next-testing 3000.3

--- a/configs/suse.tests/rhel7/products-next-testing.cfg
+++ b/configs/suse.tests/rhel7/products-next-testing.cfg
@@ -2,4 +2,4 @@
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles12sp3-products-next-testing
 MINION_IMAGE = registry.mgr.suse.de/toaster-rhel7-products-next-testing
-TAGS = rhel rhel7 products-next-testing salt-3000
+TAGS = rhel rhel7 products-next-testing salt-3000.3

--- a/configs/suse.tests/rhel7/products-next.cfg
+++ b/configs/suse.tests/rhel7/products-next.cfg
@@ -2,4 +2,4 @@
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles12sp3-products-next
 MINION_IMAGE = registry.mgr.suse.de/toaster-rhel7-products-next
-TAGS = rhel rhel7 products-next salt-3000.3
+TAGS = rhel rhel7 products-next 3000.3

--- a/configs/suse.tests/rhel7/products-next.cfg
+++ b/configs/suse.tests/rhel7/products-next.cfg
@@ -2,4 +2,4 @@
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles12sp3-products-next
 MINION_IMAGE = registry.mgr.suse.de/toaster-rhel7-products-next
-TAGS = rhel rhel7 products-next salt-2017.7
+TAGS = rhel rhel7 products-next salt-3000.3

--- a/configs/suse.tests/rhel7/products-testing.cfg
+++ b/configs/suse.tests/rhel7/products-testing.cfg
@@ -2,4 +2,4 @@
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles12sp3-products-testing
 MINION_IMAGE = registry.mgr.suse.de/toaster-rhel7-products-testing
-TAGS = rhel rhel7 products-testing 2019.2.0
+TAGS = rhel rhel7 products-testing 3000

--- a/configs/suse.tests/rhel8/products-next-testing.cfg
+++ b/configs/suse.tests/rhel8/products-next-testing.cfg
@@ -2,4 +2,4 @@
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles15sp1-products-next-testing
 MINION_IMAGE = registry.mgr.suse.de/toaster-rhel8-products-next-testing
-TAGS = rhel rhel8 products-next-testing salt-3000
+TAGS = rhel rhel8 products-next-testing salt-3000.3

--- a/configs/suse.tests/rhel8/products-next-testing.cfg
+++ b/configs/suse.tests/rhel8/products-next-testing.cfg
@@ -2,4 +2,4 @@
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles15sp1-products-next-testing
 MINION_IMAGE = registry.mgr.suse.de/toaster-rhel8-products-next-testing
-TAGS = rhel rhel8 products-next-testing salt-3000.3
+TAGS = rhel rhel8 products-next-testing 3000.3

--- a/configs/suse.tests/rhel8/products-next.cfg
+++ b/configs/suse.tests/rhel8/products-next.cfg
@@ -2,4 +2,4 @@
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles12sp3-products-next
 MINION_IMAGE = registry.mgr.suse.de/toaster-rhel8-products-next
-TAGS = rhel rhel8 products-next salt-2017.7
+TAGS = rhel rhel8 products-next salt-3000.3

--- a/configs/suse.tests/rhel8/products-next.cfg
+++ b/configs/suse.tests/rhel8/products-next.cfg
@@ -2,4 +2,4 @@
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles12sp3-products-next
 MINION_IMAGE = registry.mgr.suse.de/toaster-rhel8-products-next
-TAGS = rhel rhel8 products-next salt-3000.3
+TAGS = rhel rhel8 products-next 3000.3

--- a/configs/suse.tests/rhel8/products.cfg
+++ b/configs/suse.tests/rhel8/products.cfg
@@ -2,4 +2,4 @@
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles12sp3-products
 MINION_IMAGE = registry.mgr.suse.de/toaster-rhel8-products
-TAGS = rhel rhel8 products 2019.2.0
+TAGS = rhel rhel8 products 3000

--- a/configs/suse.tests/sles12sp2/devel.cfg
+++ b/configs/suse.tests/sles12sp2/devel.cfg
@@ -1,4 +1,4 @@
 [tool:pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles12sp2-devel
-TAGS = sles sles12sp2 devel salt-2017.7
+TAGS = sles sles12sp2 devel

--- a/configs/suse.tests/sles12sp3/devel.cfg
+++ b/configs/suse.tests/sles12sp3/devel.cfg
@@ -1,4 +1,4 @@
 [tool:pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles12sp3-devel
-TAGS = sles sles12sp3 devel salt-2017.7
+TAGS = sles sles12sp3 devel

--- a/configs/suse.tests/sles12sp3/products-next-testing.cfg
+++ b/configs/suse.tests/sles12sp3/products-next-testing.cfg
@@ -1,4 +1,4 @@
 [tool:pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles12sp3-products-next-testing
-TAGS = sles sles12sp3 products-next-testing salt-3000
+TAGS = sles sles12sp3 products-next-testing 3000.3

--- a/configs/suse.tests/sles12sp4/devel.cfg
+++ b/configs/suse.tests/sles12sp4/devel.cfg
@@ -1,4 +1,4 @@
 [tool:pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles12sp4-devel
-TAGS = sles sles12sp4 devel salt-2017.7
+TAGS = sles sles12sp4 devel

--- a/configs/suse.tests/sles12sp4/products-next-testing.cfg
+++ b/configs/suse.tests/sles12sp4/products-next-testing.cfg
@@ -1,4 +1,4 @@
 [tool:pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles12sp4-products-next-testing
-TAGS = sles sles12sp4 products-next-testing salt-3000.3
+TAGS = sles sles12sp4 products-next-testing 3000.3

--- a/configs/suse.tests/sles12sp4/products-next-testing.cfg
+++ b/configs/suse.tests/sles12sp4/products-next-testing.cfg
@@ -1,4 +1,4 @@
 [tool:pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles12sp4-products-next-testing
-TAGS = sles sles12sp4 products-next-testing salt-3000
+TAGS = sles sles12sp4 products-next-testing salt-3000.3

--- a/configs/suse.tests/sles12sp4/products-next.cfg
+++ b/configs/suse.tests/sles12sp4/products-next.cfg
@@ -1,4 +1,4 @@
 [tool:pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles12sp4-products-next
-TAGS = sles sles12sp4 products-next salt-3000.3
+TAGS = sles sles12sp4 products-next 3000.3

--- a/configs/suse.tests/sles12sp4/products-next.cfg
+++ b/configs/suse.tests/sles12sp4/products-next.cfg
@@ -1,4 +1,4 @@
 [tool:pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles12sp4-products-next
-TAGS = sles sles12sp4 products-next salt-2017.7
+TAGS = sles sles12sp4 products-next salt-3000.3

--- a/configs/suse.tests/sles12sp4/products.cfg
+++ b/configs/suse.tests/sles12sp4/products.cfg
@@ -1,4 +1,4 @@
 [tool:pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles12sp4-products
-TAGS = sles sles12sp4 products 2019.2.0
+TAGS = sles sles12sp4 products 3000

--- a/configs/suse.tests/sles15/devel.cfg
+++ b/configs/suse.tests/sles15/devel.cfg
@@ -2,4 +2,4 @@
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles15-devel
 MINION_IMAGE = registry.mgr.suse.de/toaster-sles15-devel
-TAGS = sles sles15 devel 2018.3.0
+TAGS = sles sles15 devel

--- a/configs/suse.tests/sles15/products-cross.cfg
+++ b/configs/suse.tests/sles15/products-cross.cfg
@@ -2,4 +2,4 @@
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles15-products
 MINON_IMAGE = registry.mgr.suse.de/toaster-sles15-products-next-testing
-TAGS = sles sles15 products-next-testing 2019.2.0 salt-3000
+TAGS = sles sles15 products-next-testing 2019.2.0 3000

--- a/configs/suse.tests/sles15/products-next-testing.cfg
+++ b/configs/suse.tests/sles15/products-next-testing.cfg
@@ -1,4 +1,4 @@
 [tool:pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles15-products-next-testing
-TAGS = sles sles15 products-next-testing salt-3000
+TAGS = sles sles15 products-next-testing salt-3000.3

--- a/configs/suse.tests/sles15/products-next-testing.cfg
+++ b/configs/suse.tests/sles15/products-next-testing.cfg
@@ -1,4 +1,4 @@
 [tool:pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles15-products-next-testing
-TAGS = sles sles15 products-next-testing salt-3000.3
+TAGS = sles sles15 products-next-testing 3000.3

--- a/configs/suse.tests/sles15/products-next.cfg
+++ b/configs/suse.tests/sles15/products-next.cfg
@@ -1,4 +1,4 @@
 [tool:pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles15-products-next
-TAGS = sles sles15 products-next salt-2018.3.0
+TAGS = sles sles15 products-next salt-3000.3

--- a/configs/suse.tests/sles15/products-next.cfg
+++ b/configs/suse.tests/sles15/products-next.cfg
@@ -1,4 +1,4 @@
 [tool:pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles15-products-next
-TAGS = sles sles15 products-next salt-3000.3
+TAGS = sles sles15 products-next 3000.3

--- a/configs/suse.tests/sles15/products.cfg
+++ b/configs/suse.tests/sles15/products.cfg
@@ -1,0 +1,4 @@
+[tool:pytest]
+addopts = --tb=short
+IMAGE = registry.mgr.suse.de/toaster-sles15-products
+TAGS = sles sles15 products salt-2019.2.2 python3

--- a/configs/suse.tests/sles15/products.cfg
+++ b/configs/suse.tests/sles15/products.cfg
@@ -1,4 +1,4 @@
 [tool:pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles15-products
-TAGS = sles sles15 products salt-2019.2.2 python3
+TAGS = sles sles15 products salt-3000 python3

--- a/configs/suse.tests/sles15/products.cfg
+++ b/configs/suse.tests/sles15/products.cfg
@@ -1,4 +1,4 @@
 [tool:pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles15-products
-TAGS = sles sles15 products salt-3000 python3
+TAGS = sles sles15 products 3000 python3

--- a/configs/suse.tests/sles15sp1/products-cross.cfg
+++ b/configs/suse.tests/sles15sp1/products-cross.cfg
@@ -2,4 +2,4 @@
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles15sp1-products
 MINION_IMAGE = registry.mgr.suse.de/toaster-sles15sp1-products-next-testing
-TAGS = sles sles15sp1 products-next-testing salt-3000
+TAGS = sles sles15sp1 products-next-testing 3000.3

--- a/configs/suse.tests/sles15sp1/products-next-testing.cfg
+++ b/configs/suse.tests/sles15sp1/products-next-testing.cfg
@@ -1,4 +1,4 @@
 [tool:pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles15sp1-products-next-testing
-TAGS = sles sles15sp1 products-next-testing salt-3000.3
+TAGS = sles sles15sp1 products-next-testing 3000.3

--- a/configs/suse.tests/sles15sp1/products-next-testing.cfg
+++ b/configs/suse.tests/sles15sp1/products-next-testing.cfg
@@ -1,4 +1,4 @@
 [tool:pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles15sp1-products-next-testing
-TAGS = sles sles15sp1 products-next-testing salt-3000
+TAGS = sles sles15sp1 products-next-testing salt-3000.3

--- a/configs/suse.tests/sles15sp1/products-next.cfg
+++ b/configs/suse.tests/sles15sp1/products-next.cfg
@@ -1,4 +1,4 @@
 [tool:pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles15sp1-products-next
-TAGS = sles sles15sp1 products-next salt-3000.3
+TAGS = sles sles15sp1 products-next 3000.3

--- a/configs/suse.tests/sles15sp1/products-next.cfg
+++ b/configs/suse.tests/sles15sp1/products-next.cfg
@@ -1,4 +1,4 @@
 [tool:pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles15sp1-products-next
-TAGS = sles sles15sp1 products-next salt-2019.2.0
+TAGS = sles sles15sp1 products-next salt-3000.3

--- a/configs/suse.tests/sles15sp1/products.cfg
+++ b/configs/suse.tests/sles15sp1/products.cfg
@@ -1,0 +1,4 @@
+[tool:pytest]
+addopts = --tb=short
+IMAGE = registry.mgr.suse.de/toaster-sles15sp1-products
+TAGS = sles sles15sp1 products salt-2019.2.2 python3

--- a/configs/suse.tests/sles15sp1/products.cfg
+++ b/configs/suse.tests/sles15sp1/products.cfg
@@ -1,4 +1,4 @@
 [tool:pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles15sp1-products
-TAGS = sles sles15sp1 products salt-2019.2.2 python3
+TAGS = sles sles15sp1 products salt-3000 python3

--- a/configs/suse.tests/sles15sp1/products.cfg
+++ b/configs/suse.tests/sles15sp1/products.cfg
@@ -1,4 +1,4 @@
 [tool:pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles15sp1-products
-TAGS = sles sles15sp1 products salt-3000 python3
+TAGS = sles sles15sp1 products 3000 python3

--- a/configs/suse.tests/sles15sp2/devel.cfg
+++ b/configs/suse.tests/sles15sp2/devel.cfg
@@ -1,4 +1,4 @@
 [tool:pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles15sp2-devel
-TAGS = sles sles15sp2 devel salt-3000.3 python3
+TAGS = sles sles15sp2 devel python3

--- a/configs/suse.tests/sles15sp2/devel.cfg
+++ b/configs/suse.tests/sles15sp2/devel.cfg
@@ -1,4 +1,4 @@
 [tool:pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles15sp2-devel
-TAGS = sles sles15sp2 devel salt-2019.2.2 python3
+TAGS = sles sles15sp2 devel salt-3000.3 python3

--- a/configs/suse.tests/sles15sp2/products-cross.cfg
+++ b/configs/suse.tests/sles15sp2/products-cross.cfg
@@ -2,4 +2,4 @@
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles15sp2-products
 MINOIN_IMAGE = registry.mgr.suse.de/toaster-sles15sp2-products-next-testing
-TAGS = sles sles15sp2 products-next-testing salt-3000 python3
+TAGS = sles sles15sp2 products-next-testing 3000.3 python3

--- a/configs/suse.tests/sles15sp2/products-next-testing.cfg
+++ b/configs/suse.tests/sles15sp2/products-next-testing.cfg
@@ -1,4 +1,4 @@
 [tool:pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles15sp2-products-next-testing
-TAGS = sles sles15sp2 products-next-testing salt-3000 python3
+TAGS = sles sles15sp2 products-next-testing salt-3000.3 python3

--- a/configs/suse.tests/sles15sp2/products-next-testing.cfg
+++ b/configs/suse.tests/sles15sp2/products-next-testing.cfg
@@ -1,4 +1,4 @@
 [tool:pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles15sp2-products-next-testing
-TAGS = sles sles15sp2 products-next-testing salt-3000.3 python3
+TAGS = sles sles15sp2 products-next-testing 3000.3 python3

--- a/configs/suse.tests/sles15sp2/products-next.cfg
+++ b/configs/suse.tests/sles15sp2/products-next.cfg
@@ -1,4 +1,4 @@
 [tool:pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles15sp2-products-next
-TAGS = sles sles15sp2 products-next salt-3000.3 python3
+TAGS = sles sles15sp2 products-next 3000.3 python3

--- a/configs/suse.tests/sles15sp2/products-next.cfg
+++ b/configs/suse.tests/sles15sp2/products-next.cfg
@@ -1,4 +1,4 @@
 [tool:pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles15sp2-products-next
-TAGS = sles sles15sp2 products-next salt-2019.2.2 python3
+TAGS = sles sles15sp2 products-next salt-3000.3 python3

--- a/configs/suse.tests/sles15sp2/products-testing.cfg
+++ b/configs/suse.tests/sles15sp2/products-testing.cfg
@@ -1,4 +1,4 @@
 [tool:pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles15sp2-products-testing
-TAGS = sles sles15sp2 products-testing salt-2019.2.2 python3
+TAGS = sles sles15sp2 products-testing salt-3000 python3

--- a/configs/suse.tests/sles15sp2/products-testing.cfg
+++ b/configs/suse.tests/sles15sp2/products-testing.cfg
@@ -1,4 +1,4 @@
 [tool:pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles15sp2-products-testing
-TAGS = sles sles15sp2 products-testing salt-3000 python3
+TAGS = sles sles15sp2 products-testing 3000 python3

--- a/configs/suse.tests/sles15sp2/products.cfg
+++ b/configs/suse.tests/sles15sp2/products.cfg
@@ -1,4 +1,4 @@
 [tool:pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles15sp2-products
-TAGS = sles sles15sp2 products salt-2019.2.2 python3
+TAGS = sles sles15sp2 products salt-3000 python3

--- a/configs/suse.tests/sles15sp2/products.cfg
+++ b/configs/suse.tests/sles15sp2/products.cfg
@@ -1,4 +1,4 @@
 [tool:pytest]
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles15sp2-products
-TAGS = sles sles15sp2 products salt-3000 python3
+TAGS = sles sles15sp2 products 3000 python3

--- a/configs/suse.tests/tumbleweed/devel.cfg
+++ b/configs/suse.tests/tumbleweed/devel.cfg
@@ -2,4 +2,4 @@
 addopts = --tb=short
 IMAGE = salttoaster/toaster-tumbleweed-devel
 MINION_IMAGE = salttoaster/toaster-tumbleweed-devel
-TAGS = sles tumbleweed devel 2019.2.0
+TAGS = sles tumbleweed devel 3000.3

--- a/configs/suse.tests/tumbleweed/devel.cfg
+++ b/configs/suse.tests/tumbleweed/devel.cfg
@@ -2,4 +2,4 @@
 addopts = --tb=short
 IMAGE = salttoaster/toaster-tumbleweed-devel
 MINION_IMAGE = salttoaster/toaster-tumbleweed-devel
-TAGS = sles tumbleweed devel 3000.3
+TAGS = sles tumbleweed devel

--- a/configs/suse.tests/ubuntu1604/products-testing.cfg
+++ b/configs/suse.tests/ubuntu1604/products-testing.cfg
@@ -2,4 +2,4 @@
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles12sp3-products-testing
 MINION_IMAGE = registry.mgr.suse.de/toaster-ubuntu1604-products-testing
-TAGS = ubuntu ubuntu1604 products-testing 2019.2.0
+TAGS = ubuntu ubuntu1604 products-testing 3000

--- a/configs/suse.tests/ubuntu1604/products.cfg
+++ b/configs/suse.tests/ubuntu1604/products.cfg
@@ -2,4 +2,4 @@
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles12sp3-products
 MINION_IMAGE = registry.mgr.suse.de/toaster-ubuntu1604-products
-TAGS = ubuntu ubuntu1604 products 2019.2.0
+TAGS = ubuntu ubuntu1604 products 3000

--- a/configs/suse.tests/ubuntu1804/products-testing.cfg
+++ b/configs/suse.tests/ubuntu1804/products-testing.cfg
@@ -2,4 +2,4 @@
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles12sp3-products-testing
 MINION_IMAGE = registry.mgr.suse.de/toaster-ubuntu1804-products-testing
-TAGS = ubuntu ubuntu1804 products-testing 2019.2.0
+TAGS = ubuntu ubuntu1804 products-testing 3000

--- a/configs/suse.tests/ubuntu1804/products.cfg
+++ b/configs/suse.tests/ubuntu1804/products.cfg
@@ -2,4 +2,4 @@
 addopts = --tb=short
 IMAGE = registry.mgr.suse.de/toaster-sles12sp3-products
 MINION_IMAGE = registry.mgr.suse.de/toaster-ubuntu1804-products
-TAGS = ubuntu ubuntu1804 products 2019.2.0
+TAGS = ubuntu ubuntu1804 products 3000


### PR DESCRIPTION
This PR add the missing configuration files for SLES15/SLES15SP1 for the SUSE integration tests on products.
The toaster job test for SLES15 complains that this config file is missing:

```bash
FileNotFoundError: [Errno 2] No such file or directory: './configs/suse.tests/sles15/products.cfg'
```