### PR TITLE
Do not allow pip to install latest version of virtualenv to avoid VerboseLogger error

### DIFF
--- a/images/templates/base.jinja
+++ b/images/templates/base.jinja
@@ -38,6 +38,7 @@ ARG CACHE_DATE=nocache
 # RUN pip install moto
 
 {% if flavor in ["products", "products-testing", "products-next", "products-next-testing", "devel"] -%}
+RUN pip install virtualenv==20.0.20  # nox dependency - higher versions produces VerboseLogger error
 RUN pip install nox
 {%- endif %}
 {% endblock pip %}

--- a/images/templates/ubuntu.jinja
+++ b/images/templates/ubuntu.jinja
@@ -27,5 +27,6 @@ RUN pip3 --trusted-host pypi.python.org install --upgrade pytest==3.6.1 pytest-t
 
 {% block pip %}
 RUN pip3 install -U psutil pytest-tempdir
+RUN pip3 install virtualenv==20.0.20  # nox dependency - higher versions produces VerboseLogger error
 RUN pip3 install nox
 {% endblock pip %}


### PR DESCRIPTION
This PR fixes the following error when running integration tests:

```
AttributeError: 'VerboseLogger' object has no attribute 'trace'
```

To prevent this issue, we cannot allow "pip" to automatically install latest version of "virtualenv" as "nox" dependency but instead we set a fixed version which does not bring the conflicting code.

After this PR, the generated images will have the right "virtualenv" python library version installed and the "VerboseLogger" errors shouldn't happen anymore.