### PR TITLE
Add Template for Leap 15.4 / SLES 15 SP4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,7 @@ list_targets: title
 	@echo "  openSUSE Leap 15.1      DISTRO: leap15.1     - FLAVOR: devel"
 	@echo "  openSUSE Leap 15.2      DISTRO: leap15.2     - FLAVOR: devel"
 	@echo "  openSUSE Leap 15.3      DISTRO: leap15.3     - FLAVOR: devel"
+	@echo "  openSUSE Leap 15.4      DISTRO: leap15.4     - FLAVOR: products, products-testing, devel"
 	@echo "  openSUSE Tumbleweed     DISTRO: tumbleweed   - FLAVOR: devel"
 	@echo "  CentOS 7                DISTRO: centos7      - FLAVOR: devel"
 	@echo "  Ubuntu 16.04            DISTRO: ubuntu16.04  - FLAVOR: devel"

--- a/bin/install_salt_sources.sh
+++ b/bin/install_salt_sources.sh
@@ -6,9 +6,8 @@ if [ "$FLAVOR" != "devel" ]
         if [[ "$DISTRO" =~ ^rhel ]]
             then
                 bin/rhel_unpack_salt.sh
-        elif [[ "$DISTRO" =~ ^sles ]]
+        elif [[ "$DISTRO" =~ ^(sles|leap) ]]
             then
-                /root/bin/install_salt.sh
                 bin/sles_unpack_salt.sh
         elif [[ "$DISTRO" =~ ^ubuntu ]]
             then

--- a/configs/suse.tests/leap15.4/products-testing.cfg
+++ b/configs/suse.tests/leap15.4/products-testing.cfg
@@ -1,0 +1,5 @@
+[tool:pytest]
+addopts = --tb=short
+IMAGE = salttoaster/toaster-leap15.4-products-testing
+MINION_IMAGE = salttoaster/toaster-leap15.4-products-testing
+TAGS = leap15.4 products opensuse

--- a/configs/suse.tests/leap15.4/products.cfg
+++ b/configs/suse.tests/leap15.4/products.cfg
@@ -1,0 +1,5 @@
+[tool:pytest]
+addopts = --tb=short
+IMAGE = salttoaster/toaster-leap15.4-products
+MINION_IMAGE = salttoaster/toaster-leap15.4-products
+TAGS = leap15.4 products opensuse

--- a/images/templates/leap.jinja
+++ b/images/templates/leap.jinja
@@ -1,0 +1,45 @@
+{% extends "base.jinja" %}
+{% block baserepos %}
+{% endblock baserepos %}
+
+{%- block testpackages %}
+RUN zypper --non-interactive addrepo --refresh \
+    obs://systemsmanagement:/saltstack:/testing:/testpackages/{{ salt_repo_name }} testpackages
+RUN zypper --non-interactive --gpg-auto-import-keys refresh
+{% endblock testpackages -%}
+
+{%- block salt %}
+{%- if flavor != "devel" %}
+RUN zypper --non-interactive addrepo --refresh {{ salt_repo_url }} salt
+RUN zypper --non-interactive modifyrepo --priority 1 salt
+RUN zypper --non-interactive --gpg-auto-import-keys refresh
+{% endif -%}
+{% endblock salt %}
+
+{%- block preinstall -%}
+# bind-utils: needed for tests that use `dig`
+# libopenssl-devel, libcurl-devel: needed by nox+pip
+RUN zypper --non-interactive install make python3-pip bind-utils libopenssl-devel libcurl-devel
+RUN zypper --non-interactive install --force-resolution patch rpmbuild
+RUN useradd -ms /bin/bash nobody
+{% endblock preinstall -%}
+
+{%- block install %}
+RUN zypper --non-interactive up zypper libzypp
+{%- if flavor == "devel" %}
+RUN zypper --non-interactive install python3-devel swig gcc-c++ libopenssl-devel git \
+    curl python3-pytest python3-PyYAML python3-Jinja2 python3-pyzmq python3-M2Crypto python3-mock\
+    python3-apache-libcloud python3-six python3-dateutil python3-pyOpenSSL
+RUN mkdir -p /etc/salt
+RUN touch /etc/salt/master
+RUN touch /etc/salt/minion
+{% else %}
+RUN zypper --non-interactive in salt-master salt-minion salt-proxy salt-ssh git curl
+{% endif -%}
+{% endblock install %}
+
+{%- block postinstall %}
+{%- endblock postinstall %}
+
+{% block postpip %}
+{% endblock postpip %}

--- a/images/templates/leap15.4.jinja
+++ b/images/templates/leap15.4.jinja
@@ -1,0 +1,1 @@
+{% extends "leap.jinja" %}

--- a/images/utils.py
+++ b/images/utils.py
@@ -103,6 +103,8 @@ def get_salt_repo_name(distro):
         return 'CentOS_{0}'.format(version_major)
     elif vendor == 'fedora':
         return 'Fedora_{0}'.format(version_major)
+    elif vendor in ['sles', 'leap'] and (int(version_major), int(version_minor or "0")) >= (15, 3):
+        return '{}.{}'.format(version_major, version_minor)
     elif vendor == 'sles':
         return 'SLE_{0}_SP{1}'.format(version_major, version_minor)
     elif vendor == 'leap':

--- a/images/utils.py
+++ b/images/utils.py
@@ -150,8 +150,8 @@ def generate_docker_from(distro) -> str:
         parent_image = 'opensuse/tumbleweed'
     elif distro.name == 'centos':
         parent_image = '{0}/{1}:{2}'.format(image_registry, distro.name, distro.major)
-    else:
-        parent_image = '{0}/{1}:{2}.{3}'.format(image_registry, distro.name, distro.major, distro.minor)
+    else: # sles
+        parent_image = '{0}/{1}{2}sp{3}'.format(image_registry, distro.name, distro.major, distro.minor)
     return parent_image
 
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -129,6 +129,14 @@ GRAINS_EXPECTATIONS = {
         'osrelease': '42.3',
         'osrelease_info': [42, 3],
     },
+    'leap15.4': {
+        'os': 'SUSE',
+        'oscodename': 'openSUSE Leap 15.4',
+        'os_family': 'Suse',
+        'osfullname': 'Leap',
+        'osrelease': '15.4',
+        'osrelease_info': [15, 4],
+    },
     'opensuse150': {
         'os': 'SUSE',
         'oscodename': 'openSUSE Leap 15.0',

--- a/tests/test_pkg_list_products.py
+++ b/tests/test_pkg_list_products.py
@@ -103,6 +103,12 @@ def get_expectations(tags, oem=False):
             'productline': 'Leap',
             'release': '0'
         },
+       'leap15.4': {
+           'name': 'openSUSE',
+           'version': '15.4',
+           'productline': 'Leap',
+           'release': '0'
+       },
         'tumbleweed': {
             'name': 'openSUSE',
             'version': None, # Version changes on each snapshot


### PR DESCRIPTION
This image template is used for Leap 15.4 and SLES 15SP4, which use the same repo anyway (closing the leap gap!).

I tested the template with `IMAGE_REGISTRY=registry.opensuse.org`, once I pushed the official Leap 15.4 to our internal registry, template generation won't need to set that environment variable.