### PR TITLE
Generate "_version.txt" file with fixed Salt version when flavor is "devel"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 DEFAULT_REGISTRY      = salttoaster
 DEFAULT_DISTRO        = leap15.4
 DEFAULT_FLAVOR        = devel
+DEVEL_SALT_VERSION    = 3006.0
 SUSE_DEFAULT_REGISTRY = registry.mgr.suse.de
 SUSE_DEFAULT_VERSION  = sles15sp2
 SUSE_DEFAULT_FLAVOR   = products
@@ -175,7 +176,11 @@ LEGACY_PYTEST_CMD=pytest $(LEGACY_PYTEST_ARGS) --junitxml results.xml
 # New Toaster with pytest in nox
 NOX_PYTEST_ARGS=-c $(PYTEST_CFG) $(SALT_OLDTESTS) $(SALT_PYTESTS) $(PYTEST_FLAGS)
 GOTO_SALT_ROOT=cd $(ROOT_MOUNTPOINT)/salt-*
-NOX_CMD=$(GOTO_SALT_ROOT) && mv ../conftest.py tests && nox --session 'pytest-3(coverage=False)' -- $(NOX_PYTEST_ARGS) --junitxml results.xml
+PREFLIGHT=mv ../conftest.py tests
+ifeq ("$(FLAVOR)", "devel")
+	PREFLIGHT:=$(PREFLIGHT) && echo $(DEVEL_SALT_VERSION) > salt/_version.txt
+endif
+NOX_CMD=$(GOTO_SALT_ROOT) && $(PREFLIGHT) && nox --session 'pytest-3(coverage=False)' -- $(NOX_PYTEST_ARGS) --junitxml results.xml
 
 ifeq ("$(NOX)", "True")
 CMD=$(NOX_CMD)

--- a/conftest_source_nox.py
+++ b/conftest_source_nox.py
@@ -2070,8 +2070,6 @@ KNOWN_ISSUES_UNIT = {
             'utils/test_thin.py::SSHThinTestCase::test_gen_thin_compression_fallback_py3',
 
             # contain NO_MOCK which does not exist anymore (throws ImportError)
-            'cli/test_support.py',
-            'modules/test_saltsupport.py',
             'utils/test_pkg.py',
 
             # duplicated test file, should be removed in favor of the one in tests/pytests/


### PR DESCRIPTION
This PR makes Salt Toaster to generate `_version.txt` file when `FLAVOR=devel` is set, in order to fix the Salt version before starting test execution.

For non-devel flavors, the version is set (and file already generated) at the time of building the package, but this is not the case when using toaster against a git repository.

Additionally, this PR removes some ignored salt support tests from the ignored list, as they are passing now.
